### PR TITLE
Minor changes

### DIFF
--- a/common_functions.py
+++ b/common_functions.py
@@ -10,6 +10,7 @@ import ConfigParser
 from ast import literal_eval
 import glob
 import collections
+import casadef
 
 
 # Read configuration file
@@ -203,13 +204,4 @@ def check_casaversion(logger):
     """
     Checks the casa log for the version number.
     """
-    casalogs = glob.glob('./casa*.log')
-    casalogs.sort(key=os.path.getmtime)
-    latest_log = open(casalogs[-1],'r')
-    casalog_lines = latest_log.readlines()
-    latest_log.close()
-    for line in casalog_lines:
-        if 'CASA Version' in line:
-            inx = line.index('CASA Version')
-            logger.info(line[inx:].rstrip())
-            break
+    logger.info(casadef.casa_version)

--- a/common_functions.py
+++ b/common_functions.py
@@ -182,11 +182,9 @@ def check_casalog(config,config_raw,logger):
     """
     Checks the casa log for severe errors.
     """
-    casalogs = glob.glob('./casa*.log')
-    casalogs.sort(key=os.path.getmtime)
-    latest_log = open(casalogs[-1],'r')
-    casalog_lines = latest_log.readlines()
-    latest_log.close()
+    current_log = open(casalog.logfile(), 'r')
+    casalog_lines = current_log.readlines()
+    current_log.close()
     sev_err = False
     for line in casalog_lines:
         if 'SEVERE' in line:


### PR DESCRIPTION
Hi Mike,

I have identified two small things that can improve performance and that are more robust:

- To know the filename of the current CASA log you can use casalog.logfile(). This avoids problems if the casalog filename is different from the default, and much faster.

- No need to enter all the logs to know the casa version, just need to run casadef.casa_version (much faster and safer).

If you accept this pull request you will accept the changes to the master branch.